### PR TITLE
Support default_classes as a list in extend_class

### DIFF
--- a/lib/phx_component_helpers/css.ex
+++ b/lib/phx_component_helpers/css.ex
@@ -19,9 +19,18 @@ defmodule PhxComponentHelpers.CSS do
 
   defp do_extend_class(assigns_or_options, input_class, default_classes) do
     default_classes =
-      if is_function(default_classes),
-        do: default_classes.(assigns_or_options),
-        else: default_classes
+      cond do
+        is_function(default_classes) ->
+          default_classes.(assigns_or_options)
+
+        is_list(default_classes) ->
+          default_classes
+          |> Enum.filter(&is_binary/1)
+          |> Enum.join(" ")
+
+        true ->
+          default_classes
+      end
 
     default_classes = String.split(default_classes, [" ", "\n"], trim: true)
     extend_classes = String.split(input_class, [" ", "\n"], trim: true)

--- a/lib/phx_component_helpers/css.ex
+++ b/lib/phx_component_helpers/css.ex
@@ -25,6 +25,7 @@ defmodule PhxComponentHelpers.CSS do
 
         is_list(default_classes) ->
           default_classes
+          |> List.flatten()
           |> Enum.filter(&is_binary/1)
           |> Enum.join(" ")
 

--- a/test/phx_component_helpers_test.exs
+++ b/test/phx_component_helpers_test.exs
@@ -382,13 +382,14 @@ defmodule PhxComponentHelpersTest do
           "bg-blue-500 mt-8",
           assigns[:active] == true && "text-green-500",
           nil,
+          ["flex"],
           if(assigns[:circle] == true, do: "rounded-full", else: "rounded-md")
         ])
 
       assert new_assigns ==
                assigns
-               |> Map.put(:class, "bg-blue-500 text-green-500 rounded-md mt-2")
-               |> Map.put(:heex_class, class: "bg-blue-500 text-green-500 rounded-md mt-2")
+               |> Map.put(:class, "bg-blue-500 text-green-500 flex rounded-md mt-2")
+               |> Map.put(:heex_class, class: "bg-blue-500 text-green-500 flex rounded-md mt-2")
     end
 
     test "does not extend with error_class when a form field is not faulty" do

--- a/test/phx_component_helpers_test.exs
+++ b/test/phx_component_helpers_test.exs
@@ -374,6 +374,23 @@ defmodule PhxComponentHelpersTest do
                |> Map.put(:heex_class, class: "bg-blue-500 mt-2")
     end
 
+    test "default class can be a list" do
+      assigns = %{class: "!mt* mt-2", active: true, circle: false}
+
+      new_assigns =
+        Helpers.extend_class(assigns, [
+          "bg-blue-500 mt-8",
+          assigns[:active] == true && "text-green-500",
+          nil,
+          if(assigns[:circle] == true, do: "rounded-full", else: "rounded-md")
+        ])
+
+      assert new_assigns ==
+               assigns
+               |> Map.put(:class, "bg-blue-500 text-green-500 rounded-md mt-2")
+               |> Map.put(:heex_class, class: "bg-blue-500 text-green-500 rounded-md mt-2")
+    end
+
     test "does not extend with error_class when a form field is not faulty" do
       assigns = %{
         class: "!mt* mt-2",


### PR DESCRIPTION
### What Changed
* Added support to `extend_class` to allow `default_class` to be a list.
* Resolve list, filter any non-binary elements, and combine into a single string to be assessed for class overrides


Closes #12 